### PR TITLE
[Bugfix] Prevent cumulative reward from exceeding 1.0 in continuous mode.

### DIFF
--- a/ravens/tasks/task.py
+++ b/ravens/tasks/task.py
@@ -445,6 +445,8 @@ class ContinuousOracle:
     if not self._actions:
       # Query the base oracle for pick and place poses.
       act = self._base_oracle.act(obs, info)
+      if act is None:
+          return
       self._actions = self._planner(self._env.get_ee_pose(), act['pose0'],
                                     act['pose1'])
     act = self._actions.pop(0)

--- a/ravens/tasks/task.py
+++ b/ravens/tasks/task.py
@@ -268,7 +268,10 @@ class Task():
         self.goals.pop(0)
 
     else:
-      reward = self.progress
+      # At this point we are done with the task but executing the last movements
+      # in the plan. We should return 0 reward to prevent the total reward from
+      # exceeding 1.0.
+      reward = 0.0
 
     return reward, info
 


### PR DESCRIPTION
This corrects an error I made in returning > 0 reward after the task was complete but the robot was still executing the last movements in a plan (e.g. postplace pose, home pose). The reward is now correctly capped at 1.0 for all tasks.