### PR TITLE
Add option to use EGL rendering for Linux systems when `disp=False`.

### DIFF
--- a/ravens/environments/environment.py
+++ b/ravens/environments/environment.py
@@ -15,7 +15,9 @@
 
 """Environment class."""
 
+import pkgutil
 import os
+import sys
 import tempfile
 import time
 
@@ -44,7 +46,8 @@ class Environment(gym.Env):
                task=None,
                disp=False,
                shared_memory=False,
-               hz=240):
+               hz=240,
+               use_egl=False):
     """Creates OpenAI Gym-style environment with PyBullet.
 
     Args:
@@ -54,10 +57,15 @@ class Environment(gym.Env):
       disp: show environment with PyBullet's built-in display viewer.
       shared_memory: run with shared memory.
       hz: PyBullet physics simulation step speed. Set to 480 for deformables.
+      use_egl: Whether to use EGL rendering. Only supported on Linux. Should get a
+        significant speedup in rendering when using.
 
     Raises:
       RuntimeError: if pybullet cannot load fileIOPlugin.
     """
+    if use_egl and disp:
+      raise ValueError("EGL rendering cannot be used with `disp=True`.")
+
     self.pix_size = 0.003125
     self.obj_ids = {'fixed': [], 'rigid': [], 'deformable': []}
     self.homej = np.array([-1, -0.5, 0.5, -0.5, -0.5, 0]) * np.pi
@@ -109,6 +117,13 @@ class Environment(gym.Env):
           textArgument=assets_root,
           intArgs=[p.AddFileIOAction],
           physicsClientId=client)
+
+    self._egl_plugin = None
+    if use_egl:
+      assert sys.platform == "linux", "EGL rendering is only supported on Linux."
+      self._egl_plugin = p.loadPlugin(
+        pkgutil.get_loader("eglRenderer").get_filename(), "_eglRendererPlugin")
+      print("EGL renderering enabled.")
 
     p.configureDebugVisualizer(p.COV_ENABLE_GUI, 0)
     p.setPhysicsEngineParameter(enableFileCaching=0)
@@ -233,6 +248,11 @@ class Environment(gym.Env):
 
     return obs, reward, done, info
 
+  def close(self):
+    if self._egl_plugin is not None:
+      p.unloadPlugin(self._egl_plugin)
+    p.disconnect()
+
   def render(self, mode='rgb_array'):
     # Render only the color image from the first camera.
     # Only support rgb_array for now.
@@ -270,6 +290,8 @@ class Environment(gym.Env):
         projectionMatrix=projm,
         shadow=1,
         flags=p.ER_SEGMENTATION_MASK_OBJECT_AND_LINKINDEX,
+        # Note when use_egl is toggled, this option will not actually use openGL but
+        # EGL instead.
         renderer=p.ER_BULLET_HARDWARE_OPENGL)
 
     # Get color image.


### PR DESCRIPTION
By default, the `Environment` class was using openGL hardware accelerated rendering. By switching to EGL rendering if using a Linux system, you can get an approximately 10x speedup in each call to the `env.step` method (9.83x to be precise.) This patch also fixes a visual bug in the spatula URDF which was missing a material definition.

Tested on my Ubuntu 20.04 machine with a RTX 2080ti:

| Renderer       | Mean                | Std dev               |
|----------------|---------------------|-----------------------|
| Default openGL | 0.2252595923267878  | 0.03675561883686646   |
| EGL            | 0.02291664930695262 | 0.0037472464227214205 |

Speedup = 9.83x